### PR TITLE
Don't throw an exception when there are no active alerts

### DIFF
--- a/lib/scout_api/server.rb
+++ b/lib/scout_api/server.rb
@@ -36,6 +36,8 @@ class Scout::Server < Hashie::Mash
     if hash['active_alerts']
       @alert_hash = hash['active_alerts']
       hash.delete('active_alerts')
+    else
+      @alert_hash = []
     end
     @metrics = Scout::MetricProxy.new(self)
     super(hash)


### PR DESCRIPTION
This makes sure we always define `@alert_hash`.

/cc @itsderek23
