### PR TITLE
Add #destroy to Scout::Server

### DIFF
--- a/lib/scout_api/server.rb
+++ b/lib/scout_api/server.rb
@@ -148,6 +148,13 @@ class Scout::Server < Hashie::Mash
     response['alerts'].map { |alert| decorate_with_server(Scout::Alert.new(alert)) }
   end
 
+  # Delete this server instance. If an error occurs, a [Scout::Error] is raised.
+  #
+  # @return [true]
+  def destroy
+    Scout::Server.delete(id)
+  end
+
   # Details about all plugins for this server
   #
   # @return [Array] An array of {Scout::Plugin }objects

--- a/test/server_test.rb
+++ b/test/server_test.rb
@@ -92,5 +92,12 @@ class ServerTest < Test::Unit::TestCase
     @scout.stub_delete('clients/1234.xml','client.xml', {'status' => '200 OK'})
     assert Scout::Server.delete(1234)
   end
-  
+
+  def test_destroy
+    @scout.stub_get('clients/13431.xml', 'client.xml')
+    @scout.stub_delete('clients/13431.xml', 'client.xml', {'status' => '200 OK'})
+    server = Scout::Server.first(13431)
+    assert server.destroy
+  end
+
 end


### PR DESCRIPTION
Method to allow a Scout::Server instance to be destroyed via the instance (vs class method).

I duplicated the test stubs for get and delete instead of adding a mock gem and just mocking out Scout::Server#destroy. Probably a little bit more brittle but not sure if it was worth adding a gem. Can change this to a mock if you like.
